### PR TITLE
Add pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,25 @@
+### Purpose
+
+<!--What issue does your pull request address?-->
+
+### Directions for reviewers
+
+#### Which areas should receive a particularly close look?
+
+
+#### Is there anything that you want to discuss further?
+
+
+#### Is the pull request ready for review?
+
+
+### Manuscript checklist
+
+<!--Remove this section if the changes are not relevant to the manuscript itself-->
+
+Unless otherwise noted above, this PR will be considered ready for review when all four items have been checked.
+
+- [ ] All changes to text follow "one sentence per line" [[Manubot instructions](https://github.com/jaybee84/ml-in-rd/blob/draft-branch/USAGE.md#manubot-markdown)]
+- [ ] All citations follow the [Manubot citation instructions](https://github.com/jaybee84/ml-in-rd/blob/draft-branch/USAGE.md#citations)
+- [ ] All changes or additions to tables follow the [Manubot table instructions](https://github.com/jaybee84/ml-in-rd/blob/draft-branch/USAGE.md#tables)
+- [ ] All figures follow the [Manubot figure instructions](https://github.com/jaybee84/ml-in-rd/blob/draft-branch/USAGE.md#figures)


### PR DESCRIPTION
Here I am adding a pull request template to facilitate discussion during review and correct usage of Manubot. I also added a purpose section at the top with a hidden prompt for the issue number. 

#### Further discussion

* The purpose section seems like it would be the least important but a prompt for including context may be helpful - thoughts?
* Are there any additional questions that should go under directions for reviewers?