### PR TITLE
adding draft-branch to power ghpages

### DIFF
--- a/.github/workflows/manubot.yaml
+++ b/.github/workflows/manubot.yaml
@@ -47,7 +47,7 @@ jobs:
           name: manuscript-${{ github.run_id }}-${{ env.TRIGGERING_SHA_7 }}
           path: output
       - name: Deploy Manuscript
-        if: github.ref == 'refs/heads/master' && github.event_name == 'push' && !github.event.repository.fork
+        if: (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/draft-branch') && github.event_name == 'push' && !github.event.repository.fork
         env:
           MANUBOT_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           MANUBOT_SSH_PRIVATE_KEY: ${{ secrets.MANUBOT_SSH_PRIVATE_KEY }}


### PR DESCRIPTION
### Purpose

Our intention is to have gh-pages rendered from both draft-branch as well as master. Since most PRs will be against draft-branch, it would be great to have ease of readability for both branches.

The draft-branch (dev branch) will be reviewed more regularly as and when PRs are merged.
The master branch (prod-ready) will be reviewed more intermittently when substantial sections have been finished.

### Directions for reviewers

this is a test

#### Which areas should receive a particularly close look?

none

#### Is there anything that you want to discuss further?

none

#### Is the pull request ready for review?


### Manuscript checklist

NA