### PR TITLE
Move deploy logic in GitHub Actions workflow

### DIFF
--- a/.github/workflows/manubot.yaml
+++ b/.github/workflows/manubot.yaml
@@ -49,11 +49,17 @@ jobs:
           name: manuscript-${{ github.run_id }}-${{ env.TRIGGERING_SHA_7 }}
           path: output
       - name: Deploy Manuscript
-        if: github.ref == 'refs/heads/draft-branch' && github.event_name == 'push' && !github.event.repository.fork
+        if: github.event_name == 'push' && !github.event.repository.fork
         env:
           MANUBOT_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           MANUBOT_SSH_PRIVATE_KEY: ${{ secrets.MANUBOT_SSH_PRIVATE_KEY }}
           CI_BUILD_WEB_URL: https://github.com/${{ github.repository }}/commit/${{ github.sha }}/checks
           CI_JOB_WEB_URL: https://github.com/${{ github.repository }}/runs/${{ github.run_id }}
+          GITHUB_REF: ${{ github.ref }}
         shell: bash --login {0}
-        run: bash ci/deploy.sh
+        run: |
+          # log for debugging
+          echo Current ref: $GITHUB_REF
+          if [ "$GITHUB_REF" = "refs/heads/draft-branch" ]; then
+            bash ci/deploy.sh
+          fi


### PR DESCRIPTION
### Purpose
<!--What issue does your pull request address?-->
This begins to address the desire to deploy from `master` and/or `draft-branch`. The initial commit moves the deploy logic from the `if` statement in the workflow to the `run`  block.  In the `run` block, you can use standard bash script syntax to have full control over deploy conditions, such as the branch (ref). 
 See
- https://github.com/jaybee84/ml-in-rd/issues/17
- https://github.com/manubot/rootstock/issues/341#issuecomment-632932132

### Directions for reviewers

#### Which areas should receive a particularly close look?
The GitHub Actions log (nevermind, the deploy step does not run in a pull request, as noted below)

#### Is there anything that you want to discuss further?
Depends on whether the new logic works or fails.  This is not a complete implementation of deploying from multiple branches, but if it works you'll be able to modify it further.

#### Is the pull request ready for review?
Yes